### PR TITLE
Add github followers and following links to user dashboard

### DIFF
--- a/app/poros/follower.rb
+++ b/app/poros/follower.rb
@@ -1,0 +1,8 @@
+class Follower
+  attr_reader :login, :html_url
+
+  def initialize(attributes)
+    @login = attributes[:login]
+    @html_url = attributes[:html_url]
+  end
+end

--- a/app/poros/following.rb
+++ b/app/poros/following.rb
@@ -1,0 +1,8 @@
+class Following
+  attr_reader :login, :html_url
+
+  def initialize(attributes)
+    @login = attributes[:login]
+    @html_url = attributes[:html_url]
+  end
+end

--- a/app/poros/repo.rb
+++ b/app/poros/repo.rb
@@ -1,6 +1,5 @@
 class Repo
-  attr_reader :name,
-              :html_url
+  attr_reader :name, :html_url
 
   def initialize(attributes)
     @name = attributes[:name]

--- a/app/poros/user_info.rb
+++ b/app/poros/user_info.rb
@@ -12,4 +12,18 @@ class UserInfo
       Repo.new(repo)
     end
   end
+
+  def github_followings
+    service = GithubService.new(@token)
+    @github_followings ||= service.followings_by_user.map do |following|
+      Following.new(following)
+    end
+  end
+
+  def github_followers
+    service = GithubService.new(@token)
+    @github_followers ||= service.followers_by_user.map do |follower|
+      Follower.new(follower)
+    end
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,14 +4,22 @@ class GithubService
   end
 
   def repos_by_user
-    get_json('/user/repos')
+    get_json('/user/repos').take(5)
+  end
+
+  def followings_by_user
+    get_json('/user/following')
+  end
+
+  def followers_by_user
+    get_json('/user/followers')
   end
 
   private
 
   def get_json(url)
     response = conn.get(url)
-    JSON.parse(response.body, symbolize_names: true).take(5)
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def conn

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,13 +13,31 @@
 
   <% if search_results.user.github_token %>
     <section>
-      <h3> GitHub </h3>
-      <% search_results.github_repos.each do |repo| %>
-        <ul class='repo'>
-          <li> <%= link_to repo.name, repo.html_url %> </li>
-        </ul>
-      <% end %>
+      <h1> GitHub </h1>
+        <section class='github-repos'>
+          <h3> Repos </h3>
+            <% search_results.github_repos.each do |repo| %>
+            <ul class='repo'>
+              <li class='name'> <%= link_to repo.name, repo.html_url %> </li>
+            </ul>
+          <% end %>
+        </section>
+        <section class='github-following'>
+          <h3> Following </h3>
+            <% search_results.github_followings.each do |following| %>
+              <ul class='following'>
+                <li> <%= link_to following.login, following.html_url %></li>
+              </ul>
+            <% end %>
+        </section>
+        <section class='github_followers'>
+          <h3> Followers </h3>
+          <% search_results.github_followers.each do |follower| %>
+            <ul class='followers'>
+              <li> <%= link_to follower.login, follower.html_url %></li>
+            </ul>
+          <% end %>
+        </section>
     </section>
   <% end %>
-
 </section>

--- a/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
+++ b/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 05 Dec 2019 23:34:11 GMT
+      - Fri, 06 Dec 2019 18:33:18 GMT
       Date:
-      - Thu, 05 Dec 2019 23:34:11 GMT
+      - Fri, 06 Dec 2019 18:33:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Etag:
@@ -119,5 +119,5 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 05 Dec 2019 23:34:11 GMT
+  recorded_at: Fri, 06 Dec 2019 18:33:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,6 @@ VCR.configure do |config|
   config.filter_sensitive_data("<GITHUB_TOKEN>") { ENV['GITHUB_TOKEN'] }
 end
 
-
 ActiveRecord::Migration.maintain_test_schema!
 
 Capybara.register_driver :selenium do |app|

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,8 +1,0 @@
-# require 'rails_helper'
-#
-# describe GithubService do
-#   it "returns github data", :vcr do
-#     search = subject.repos_by_user
-#     expect(search).to be_an Array
-#   end
-# end


### PR DESCRIPTION
- Add Following and Follower POROs
- Add github_followings and github_followers methods to UserInfo PORO
- Add followings_by_user and followers_by_user methods to GitHubService
- Create sections within user dashboard for GitHub repos, followers, and followings
- Move Repos from models folder to POROs folder
- All tests passing