### PR TITLE
Add test for user to create friendships

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,20 +39,20 @@
         </section>
         <section class='github-following'>
           <h3> Following </h3>
-            <% search_results.github_followings.each do |following| %>
+            <% search_results.github_followings.each_with_index do |following, index| %>
               <ul class='following'>
-                <li class='login'> <%= link_to following.login, following.html_url %></li>
+                <li class='login' id="following-<%= index %>"> <%= link_to following.login, following.html_url %></li>
                 <% if search_results.account?(following) && following.not_already_a_friend_of(search_results.user) %>
                   <%= button_to 'Add as Friend', friendships_path(:friend_id => following.id), method: :post, class: "btn btn-primary mb1 bg-teal" %>
                 <% end %>
               </ul>
             <% end %>
         </section>
-        <section class='github_followers'>
+        <section class='github-followers'>
           <h3> Followers </h3>
-          <% search_results.github_followers.each do |follower| %>
+          <% search_results.github_followers.each_with_index do |follower, index| %>
             <ul class='followers'>
-              <li class='login'> <%= link_to follower.login, follower.html_url %>
+              <li class='login' id="followers-<%= index %>"> <%= link_to follower.login, follower.html_url %>
                 <% if search_results.account?(follower) && follower.not_already_a_friend_of(search_results.user) %>
                   <%= button_to 'Add as Friend', friendships_path(:friend_id => follower.id), method: :post, class: "btn btn-primary mb1 bg-teal" %>
                 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/features/user/user_can_create_a_friendship_spec.rb
+++ b/spec/features/user/user_can_create_a_friendship_spec.rb
@@ -1,7 +1,62 @@
-# require 'rails_helper'
-#
-# RSpec.describe 'As a user' do
-#   it 'can create a friendship' do
-#
-#   end
-# end
+require 'rails_helper'
+
+RSpec.describe 'A registered user' do
+  it 'can add as a friend a github following who has an account', :vcr do
+    user = create(:user, activated?: true, github_token: ENV['GITHUB_TOKEN_1'])
+    user_2 = create(:user, handle: 'freeheeling', activated?: true)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    within('.github-following') do
+      click_button('Add as Friend')
+    end
+
+    expect(page).to have_content('Added Friend!')
+
+    user.reload
+
+    visit dashboard_path
+
+    within('.github-following') do
+      expect(page).to_not have_button('Add as Friend')
+    end
+  end
+
+  it 'can add as a friend a github follower who has an account', :vcr do
+    user = create(:user, activated?: true, github_token: ENV['GITHUB_TOKEN_1'])
+    user_2 = create(:user, handle: 'freeheeling', activated?: true)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    within('.github-followers') do
+      click_button('Add as Friend')
+    end
+
+    expect(page).to have_content('Added Friend!')
+
+    user.reload
+
+    visit dashboard_path
+
+    within('.github-followers') do
+      expect(page).to_not have_button('Add as Friend')
+    end
+  end
+
+  it 'cannot add a github follower/following as a friend if the user does not have an account', :vcr do
+    user = create(:user, activated?: true, github_token: ENV['GITHUB_TOKEN_1'])
+    user_2 = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    within('.github-followers') do
+      expect(page).to_not have_button('Add as Friend')
+    end
+  end
+end


### PR DESCRIPTION
- Add test to validate that a registered user can add a follower/following as a friend who has an account
- Follower/following that does not have an account cannot be added as a friend